### PR TITLE
Use HTTPS to communicate with PyPI

### DIFF
--- a/lib/puppet/provider/package/pip3.rb
+++ b/lib/puppet/provider/package/pip3.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:package).provide :pip3,
   # cache of PyPI's package list so this operation will always have to
   # ask the web service.
   def latest
-    client = XMLRPC::Client.new2("http://pypi.python.org/pypi")
+    client = XMLRPC::Client.new2("https://pypi.python.org/pypi")
     client.http_header_extra = {"Content-Type" => "text/xml"}
     client.timeout = 10
     result = client.call("package_releases", @resource[:name])


### PR DESCRIPTION
See also [PUP-6413](https://github.com/puppetlabs/puppet/pull/5024).